### PR TITLE
hermes relayer version set to 0.13

### DIFF
--- a/docker/hermes-ibc-relayer/config/test-config.toml
+++ b/docker/hermes-ibc-relayer/config/test-config.toml
@@ -18,7 +18,6 @@ enabled = false
 enabled = true
 clear_interval = 100
 clear_on_start = true
-filter = false
 tx_confirmation = true
 
 [rest]

--- a/docker/hermes-ibc-relayer/hermes-ibc-relayer-binary-builder.dockerfile
+++ b/docker/hermes-ibc-relayer/hermes-ibc-relayer-binary-builder.dockerfile
@@ -16,6 +16,6 @@ RUN apt-get update
 
 RUN apt-get install cargo -y
 
-RUN cargo install ibc-relayer-cli --version 0.10.0 --bin hermes --locked
+RUN cargo install ibc-relayer-cli --version 0.13.0 --bin hermes --locked
 
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
Updated the hermes relayer binary version to the current latest - 0.13.