### PR TITLE
add envs for smart contract verification

### DIFF
--- a/docker/gravity-contract-deployer/gravity-contract-deployer.env.example
+++ b/docker/gravity-contract-deployer/gravity-contract-deployer.env.example
@@ -2,3 +2,6 @@ COSMOS_NODE=""
 ETH_NODE=""
 ETH_PRIV_KEY_HEX=""
 CUDOS_ACCESS_CONTROL_ADDRESS=""
+# default network name where the conracts would be deployed (rinkeby, mainnet)
+DEFAULT_NETWORK=""
+ETHERSCAN_API_KEY=""


### PR DESCRIPTION
* Default Network ENV -> name of the network where the contract would be deployed
* ETHERSCAN_API_KEY -> the API key needed fro Etherscan verification