### PR TITLE
Switch to updated values after GCP migration

### DIFF
--- a/docker/config/state-sync-rpc-servers.testnet.public.config
+++ b/docker/config/state-sync-rpc-servers.testnet.public.config
@@ -1,1 +1,1 @@
-http://34.67.137.129:26657,http://34.102.114.30:26657,http://34.141.129.16:26657,https://sentry1.gcp-uscentral1.cudos.org:26657,http://sentry2.gcp-uswest2.cudos.org:26657,https://sentry3.gcp-euwest4.cudos.org:26657
+https://rpc.testnet.cudos.org/


### PR DESCRIPTION
The endpoint addresses here are all being obsoleted.